### PR TITLE
Add support for Django 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.1.2][] - 2021-08-09
+
+* Added support for Django 3.2 LTS 
+
 ## [2.1.1][] - 2020-03-16
 
 * correctly specify django versions in setup.py 
@@ -72,6 +76,7 @@ This is a hotfix release to fix a broken pypi build.
 Initial release.
 
 [unreleased]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.0...HEAD
+[2.1.2]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/cloud-gov/cg-django-uaa/compare/v1.3.0...v2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = '''
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py35-django22,py3{6,7,8,9,10}-django{22,30,31}
+envlist = py35-django22,py3{6,7,8,9,10}-django{22,30,31,32}
 
 [testenv]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 commands =
     # don't run mypy on versions lower than 3.8 because there's a bug that was fixed in
     # https://github.com/python/typeshed/pull/1142 but only fixes 3.8+ versions

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     package_dir={"uaa_client": "uaa_client"},
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["django>=2.2,<3.2", "PyJWT>=1.4.2,<2.0", "requests>=2.11.0"],
+    install_requires=["django>=2.2,<3.3", "PyJWT>=1.4.2,<2.0", "requests>=2.11.0"],
     test_suite="uaa_client.runtests.run_tests",
     tests_require=open("requirements-tests.txt", "r").read().strip().split("\n"),
     classifiers=[
@@ -100,6 +100,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Intended Audience :: Developers",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "Operating System :: OS Independent",

--- a/uaa_client/__init__.py
+++ b/uaa_client/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 
 default_app_config = "uaa_client.apps.UaaClientConfig"

--- a/uaa_client/runtests.py
+++ b/uaa_client/runtests.py
@@ -52,6 +52,7 @@ SETTINGS_DICT = {
     "UAA_CLIENT_SECRET": "something_secret",
     "UAA_AUTH_URL": "https://auth.example.gov",
     "UAA_TOKEN_URL": "https://token.example.gov",
+    "SECRET_KEY": "only-for-testing",
 }
 
 # Django 2.0+


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add support for Django 3.2 LTS. 

-  - Django 2.2 LTS Extended Support is due to end on April 2022. 


- Resolves Issue #58 and #57 
- Please note that I have set the "version" to 2.1.2

## security considerations
None of note. 
