### PR TITLE
More fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements-rtd.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,6 @@ If you have any questions or want to read more, check out the
 We adhere to [PEP8][] for Python code
 formatting. Before committing, please use `black .` to autoformat your code.
 
-This project has a command to run all linters and unit tests:
-
-```sh
-python setup.py ultratest
-```
-
 For more information about developing on this project, see the
 [development guide](http://cg-django-uaa.readthedocs.io/en/latest/developing.html).
 
@@ -44,7 +38,7 @@ reading.
 [review]: https://github.com/18F/development-guide/tree/master/code_review
 [thoughts]: http://glen.nu/ramblings/oncodereview.php
 
-### Commit message style guide:
+### Commit message style guide
 
 - Write your commit message summary in the imperative: "Fix bug" and not
 "Fixed bug" or "Fixes bug."  This convention matches up with commit messages
@@ -59,7 +53,7 @@ GitHub's syntax, such as `Fixes #123`.
 
 Example:
 
-```
+```markdown
 Load seed using before(:suite) in RSpec config
 
 **Why**:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,8 +17,18 @@ Here's how to issue a new release:
    installs OK in an isolated environment:
 
    ```shell
+   # remove existing builds
    rm -rf dist build
+
+   # build source distribution
    python -m build --sdist
+
+   # install dependencies
+   python -m venv venv
+   source venv/bin/activate
+   python -m pip install .
+
+   # start up docker environment for manual tests
    python test.py manualtest
    ```
 

--- a/example/manage.py
+++ b/example/manage.py
@@ -2,6 +2,7 @@
 import os
 import sys
 
+
 def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example.settings")
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,6 @@ install_requires =
     PyJWT>=2.4.0
     requests>=2.11.0
 
-; [options.packages.find]
-; exclude =
-;     uaa_client.tests
+[options.packages.find]
+exclude =
+    uaa_client.tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,6 @@ install_requires =
     PyJWT>=2.4.0
     requests>=2.11.0
 
-[options.packages.find]
-exclude =
-    uaa_client.tests
+; [options.packages.find]
+; exclude =
+;     uaa_client.tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,3 @@ install_requires =
     django>=4.0,<5.0
     PyJWT>=2.4.0
     requests>=2.11.0
-
-[options.packages.find]
-exclude =
-    uaa_client.tests


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add `.readthedocs.yaml` to ensure that public docs (https://cg-django-uaa.readthedocs.io/) build properly
- Removed outdated info from `CONTRIBUTING.md`
- Update release process based on testing
- Remove configuration excluding tests from source distribution which was causing the manual test script to fail. I found [no definitive answer on whether this is idiomatic in Python](https://discuss.python.org/t/should-sdists-include-docs-and-tests/14578), but it's by far the easiest way to get the manual tests working properly. And my thought was that manual tests and working software is far more important than unclear style guidelines

## security considerations

No sensitive information is provided
